### PR TITLE
Upgraded to dotnet 2.1 and added docker-composer support

### DIFF
--- a/Cierge/Cierge.csproj
+++ b/Cierge/Cierge.csproj
@@ -1,29 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <UserSecretsId>aspnet-PwdLess-FFAEA828-6DB7-405C-8E94-8A5EB7C69E53</UserSecretsId>
   </PropertyGroup>
 
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.6.362" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.1.4" PrivateAssets="all">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" PrivateAssets="All" />
     <PackageReference Include="AspNet.Security.OAuth.Validation" Version="2.0.0-*" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="OpenIddict" Version="2.0.0-rc2-*" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="2.0.0-rc2-*" />
     <PackageReference Include="OpenIddict.Mvc" Version="2.0.0-rc2-*" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.1" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.0" />
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
-    <DotNetCliToolReference Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Cierge/Migrations/20180922191032_initial.Designer.cs
+++ b/Cierge/Migrations/20180922191032_initial.Designer.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using System;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Cierge.Migrations
 {

--- a/Cierge/Migrations/20180922191032_initial.cs
+++ b/Cierge/Migrations/20180922191032_initial.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore.Migrations;
 using System;
 using System.Collections.Generic;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Cierge.Migrations
 {

--- a/Cierge/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Cierge/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using System;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Cierge.Migrations
 {

--- a/Cierge/Program.cs
+++ b/Cierge/Program.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Core;
@@ -45,6 +46,7 @@ namespace Cierge
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
+                .ConfigureAppConfiguration((context, config) => config.AddUserSecrets("aspnet-PwdLess-FFAEA828-6DB7-405C-8E94-8A5EB7C69E53"))
                 .Build();
 
 

--- a/Cierge/Program.cs
+++ b/Cierge/Program.cs
@@ -2,9 +2,11 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Cierge.Data;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -54,6 +56,8 @@ namespace Cierge
         {
             using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
+                await scope.ServiceProvider.GetRequiredService<ApplicationDbContext>().Database.MigrateAsync(cancellationToken);
+
                 // Add OpenIddict clients
                 var iddictManager = scope.ServiceProvider.GetRequiredService<OpenIddictApplicationManager<OpenIddictApplication>>();
                 if (await iddictManager.FindByClientIdAsync("client-app", cancellationToken) == null)

--- a/Cierge/Program.cs
+++ b/Cierge/Program.cs
@@ -48,7 +48,6 @@ namespace Cierge
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .ConfigureAppConfiguration((context, config) => config.AddUserSecrets("aspnet-PwdLess-FFAEA828-6DB7-405C-8E94-8A5EB7C69E53"))
                 .Build();
 
 

--- a/Cierge/Startup.cs
+++ b/Cierge/Startup.cs
@@ -17,6 +17,7 @@ using System.IO;
 using Newtonsoft.Json;
 using Microsoft.AspNetCore.Mvc;
 using System.IdentityModel.Tokens.Jwt;
+using Microsoft.AspNetCore.HttpOverrides;
 
 namespace Cierge
 {
@@ -185,7 +186,10 @@ namespace Cierge
             app.UseCors("AllowSpecificOrigin");
 
             app.UseStaticFiles();
-
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                ForwardedHeaders = ForwardedHeaders.All
+            });
             app.UseAuthentication();
 
             app.UseMvc(routes =>

--- a/Cierge/Startup.cs
+++ b/Cierge/Startup.cs
@@ -209,7 +209,7 @@ namespace Cierge
             {
                 // Get RSA JSON from file
                 string jsonString;
-                FileStream fileStream = new FileStream(path, FileMode.Open);
+                FileStream fileStream = new FileStream(path, FileMode.Open, FileAccess.Read);
                 using (StreamReader reader = new StreamReader(fileStream))
                 {
                     jsonString = reader.ReadToEnd();

--- a/DemoClient/DemoClient.csproj
+++ b/DemoClient/DemoClient.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DemoResourceServer/DemoResourceServer.csproj
+++ b/DemoResourceServer/DemoResourceServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY rsa_signing_key.json /run/secrets/
 COPY cierge.appsettings.json appsettings.json
 
 ENV ASPNETCORE_ENVIRONMENT Production
+ENV ASPNETCORE_URLS "http://*:5000"
 EXPOSE 5000
 
 ENTRYPOINT ["dotnet", "Cierge.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS build
+FROM microsoft/dotnet:2.1-sdk AS build
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
@@ -10,23 +10,14 @@ RUN dotnet restore
 WORKDIR /app/
 COPY Cierge/. ./cierge/
 WORKDIR /app/cierge
-# add IL Linker package
-#RUN dotnet add package ILLink.Tasks -v 0.1.5-preview-1841731 -s https://dotnet.myget.org/F/dotnet-c$
-#RUN dotnet publish -c Release -r ubuntu.18.04-x64 -o out /p:ShowLinkerSizeComparison=true
-RUN dotnet publish -c Release --output /out/
 
-# test application -- see: dotnet-docker-unit-testing.md
-#FROM build AS testrunner
-#WORKDIR /app/tests
-#COPY tests/. .
-#ENTRYPOINT ["dotnet", "test", "--logger:trx"]
+RUN dotnet publish -c Release --output /out/
 
 FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
 WORKDIR /app
 COPY --from=build /out .
-#COPY --from=build /app/cierge/out ./
 #COPY rsa_signing_key.json /run/secrets/
 ENV ASPNETCORE_ENVIRONMENT Production
 EXPOSE 5000
 
-ENTRYPOINT ["dotnet", "cierge.dll"]
+ENTRYPOINT ["dotnet", "Cierge.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ RUN dotnet publish -c Release --output /out/
 FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
 WORKDIR /app
 COPY --from=build /out .
-COPY rsa_signing_key.json /run/secrets/
-COPY cierge.appsettings.json appsettings.json
+#COPY rsa_signing_key.json /run/secrets/
+#COPY cierge.appsettings.json appsettings.json
 
 ENV ASPNETCORE_ENVIRONMENT Production
 ENV ASPNETCORE_URLS "http://*:5000"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk-bionic AS build
+FROM microsoft/dotnet:2.1-aspnetcore-runtime AS build
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
@@ -11,8 +11,9 @@ WORKDIR /app/
 COPY Cierge/. ./cierge/
 WORKDIR /app/cierge
 # add IL Linker package
-RUN dotnet add package ILLink.Tasks -v 0.1.5-preview-1841731 -s https://dotnet.myget.org/F/dotnet-c$
-RUN dotnet publish -c Release -r ubuntu.18.04-x64 -o out /p:ShowLinkerSizeComparison=true
+#RUN dotnet add package ILLink.Tasks -v 0.1.5-preview-1841731 -s https://dotnet.myget.org/F/dotnet-c$
+#RUN dotnet publish -c Release -r ubuntu.18.04-x64 -o out /p:ShowLinkerSizeComparison=true
+RUN dotnet publish -c Release --output /out/
 
 # test application -- see: dotnet-docker-unit-testing.md
 #FROM build AS testrunner
@@ -20,11 +21,12 @@ RUN dotnet publish -c Release -r ubuntu.18.04-x64 -o out /p:ShowLinkerSizeCompar
 #COPY tests/. .
 #ENTRYPOINT ["dotnet", "test", "--logger:trx"]
 
-FROM microsoft/dotnet:2.1-runtime-bionic AS runtime
+FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
 WORKDIR /app
-COPY --from=build /app/cierge/out ./
+COPY --from=build /out .
+#COPY --from=build /app/cierge/out ./
 #COPY rsa_signing_key.json /run/secrets/
 ENV ASPNETCORE_ENVIRONMENT Production
 EXPOSE 5000
 
-ENTRYPOINT ["./cierge"]
+ENTRYPOINT ["dotnet", "cierge.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN dotnet publish -c Release --output /out/
 FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
 WORKDIR /app
 COPY --from=build /out .
-#COPY rsa_signing_key.json /run/secrets/
+COPY rsa_signing_key.json /run/secrets/
+COPY cierge.appsettings.json appsettings.json
+
 ENV ASPNETCORE_ENVIRONMENT Production
 EXPOSE 5000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk-stretch AS build
+FROM microsoft/dotnet:2.1-sdk-bionic AS build
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
@@ -8,11 +8,11 @@ RUN dotnet restore
 
 # copy and build app and libraries
 WORKDIR /app/
-COPY cierge/. ./cierge/
+COPY Cierge/. ./cierge/
 WORKDIR /app/cierge
 # add IL Linker package
-RUN dotnet add package ILLink.Tasks -v 0.1.5-preview-1841731 -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json
-RUN dotnet publish -c Release -r linux-x64 -o out /p:ShowLinkerSizeComparison=true
+RUN dotnet add package ILLink.Tasks -v 0.1.5-preview-1841731 -s https://dotnet.myget.org/F/dotnet-c$
+RUN dotnet publish -c Release -r ubuntu.18.04-x64 -o out /p:ShowLinkerSizeComparison=true
 
 # test application -- see: dotnet-docker-unit-testing.md
 #FROM build AS testrunner
@@ -20,10 +20,10 @@ RUN dotnet publish -c Release -r linux-x64 -o out /p:ShowLinkerSizeComparison=tr
 #COPY tests/. .
 #ENTRYPOINT ["dotnet", "test", "--logger:trx"]
 
-FROM microsoft/dotnet:2.1-runtime-deps-stretch-slim AS runtime
+FROM microsoft/dotnet:2.1-runtime-bionic AS runtime
 WORKDIR /app
 COPY --from=build /app/cierge/out ./
-COPY rsa_signing_key.json /run/secrets/
+#COPY rsa_signing_key.json /run/secrets/
 ENV ASPNETCORE_ENVIRONMENT Production
 EXPOSE 5000
 

--- a/RsaKeyGenerator/RsaKeyGenerator.csproj
+++ b/RsaKeyGenerator/RsaKeyGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     secrets:
       - cierge_rsa_signing_key.json
     volumes:
-      - ~/files/cierge/appsettings.json:/app/cierge/appsettings.json
+      - ~/files/cierge/appsettings.json:/app/appsettings.json
     depends_on:
       - db
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   nginx:
     image: nginx:1.15
     volumes:
-      - ~/oyeoye/Cierge/nginx.conf:/etc/nginx/nginx.conf
+      - ~/Cierge/nginx.conf:/etc/nginx/nginx.conf
     ports:
       - 80:80
       - 443:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ secrets:
     file: ~/files/cierge_nginx/fullchain.pem
   cierge_privkey.pem:
     file: ~/files/cierge_nginx/privkey.pem
+  cierge_rsa_signing_key.json:
+    file: ~/files/cierge/rsa_signing_key.json
 
 services:
   cierge:
@@ -21,6 +23,10 @@ services:
       dockerfile: Dockerfile
     expose:
       - 5000
+    secrets:
+      - cierge_rsa_signing_key.json
+    volumes:
+      - ~/files/cierge/appsettings.json:/app/cierge/appsettings.json
     depends_on:
       - db
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres
+    image: postgres:11
     environment:
       POSTGRES_DB: cierge
       POSTGRES_USER_FILE: /run/secrets/pg_user_file
@@ -43,7 +43,7 @@ services:
       - pg_user_file
       - pg_pwd_file
   nginx:
-    image: nginx:latest
+    image: nginx:1.15
     volumes:
       - ~/oyeoye/Cierge/nginx.conf:/etc/nginx/nginx.conf
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.3'
+
+volumes:
+  pgdata:
+    driver: local
+
+secrets:
+  pg_pwd_file:
+    file: ~/files/postgres/pg_pwd_file.txt
+  pg_user_file:
+    file: ~/files/postgres/pg_user_file.txt
+  cierge_fullchain.pem:
+    file: ~/files/cierge_nginx/fullchain.pem
+  cierge_privkey.pem:
+    file: ~/files/cierge_nginx/privkey.pem
+
+services:
+  cierge:
+    build:
+      context:  .
+      dockerfile: Dockerfile
+    expose:
+      - 5000
+    depends_on:
+      - db
+  db:
+    image: postgres
+    environment:
+      POSTGRES_DB: cierge
+      POSTGRES_USER_FILE: /run/secrets/pg_user_file
+      POSTGRES_PASSWORD_FILE: /run/secrets/pg_pwd_file
+      POSTGRES_INITDB_ARGS: --data-checksums
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    secrets:
+      - pg_user_file
+      - pg_pwd_file
+  nginx:
+    image: nginx:latest
+    volumes:
+      - ~/oyeoye/Cierge/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - 80:80
+      - 443:443
+    links:
+      - cierge
+    secrets:
+      - cierge_fullchain.pem
+      - cierge_privkey.pem

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,34 @@
+worker_processes  1;
+events {
+	worker_connections  128;
+}
+
+http {
+	upstream kestrel {
+	server cierge:5000;
+	}
+
+	server {
+		listen *:80;
+		add_header Strict-Transport-Security max-age=15768000;
+		return 301 https://$host$request_uri;
+	}
+
+	server {
+		listen *:443 ssl;
+		ssl_certificate /run/secrets/cierge_fullchain.pem;
+		ssl_certificate_key /run/secrets/cierge_privkey.pem;	
+		ssl_protocols TLSv1.1 TLSv1.2;
+		ssl_prefer_server_ciphers on;
+		ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+		ssl_ecdh_curve secp384r1;
+		ssl_session_cache shared:SSL:10m;
+		ssl_session_tickets off;
+		add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+		add_header X-Frame-Options DENY;
+		add_header X-Content-Type-Options nosniff;
+		location / {
+			proxy_pass      http://kestrel;
+		}
+	}
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -29,6 +29,13 @@ http {
 		add_header X-Content-Type-Options nosniff;
 		location / {
 			proxy_pass      http://kestrel;
+			proxy_http_version 1.1;
+			proxy_set_header   Upgrade $http_upgrade;
+			proxy_set_header   Connection keep-alive;
+			proxy_set_header   Host $host;
+			proxy_cache_bypass $http_upgrade;
+			proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header   X-Forwarded-Proto $scheme;
 		}
 	}
 }


### PR DESCRIPTION
This will do 2 things
 -  Updated to dotnet 2.1
 -  Run postgres, nginx, and cierge in their own containers using `docker-compose.yml` file

Before running `docker-compose up` you need to make sure that following files present in current user home directory. which are
 - `~/files/postgres/pg_pwd_file.txt` Contains postgres password
 - `~/files/postgres/pg_user_file.txt` contains postgres username

 - `~/files/cierge_nginx/fullchain.pem` SSL Certificate public key
 - `~/files/cierge_nginx/privkey.pem` SSL private key

 - `~/files/cierge/rsa_signing_key.json` RSA Signing key which is used by Cierge
 - `~/files/cierge/appsettings.json` Production appsetting
